### PR TITLE
Fix MultiplayerModeSelectionFlowCoordinatorPatch, Remove ConnectToMatchmakingPatch, Improve CenterScreenLoadingPanel

### DIFF
--- a/MultiplayerExtensions/Downloader.cs
+++ b/MultiplayerExtensions/Downloader.cs
@@ -49,7 +49,7 @@ namespace MultiplayerExtensions
             byte[]? beatmapBytes = await bm.Versions.ToList().Find(version => {
                 Plugin.Log?.Info($"Version: '{version.Key}' '{version.Hash}'");
                 return version.Hash.ToUpper() == hash;
-            }).DownloadZIP(progress: UI.CenterScreenLoadingPanel.self);
+            }).DownloadZIP(progress: UI.CenterScreenLoadingPanel.Instance);
 #if DEBUG
             TimeSpan delay = TimeSpan.FromSeconds(Plugin.Config.DebugConfig?.MinDownloadTime ?? 0) - TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds);
             if (delay > TimeSpan.Zero)

--- a/MultiplayerExtensions/Extensions/ExtendedEntitlementChecker.cs
+++ b/MultiplayerExtensions/Extensions/ExtendedEntitlementChecker.cs
@@ -118,7 +118,10 @@ namespace MultiplayerExtensions.Extensions
         {
 			if (_entitlementsDictionary.TryGetValue(userId, out Dictionary<string, EntitlementsStatus> userDictionary))
 				if (userDictionary.TryGetValue(levelId, out EntitlementsStatus entitlement) && entitlement == EntitlementsStatus.Ok)
+                {
+                    UI.CenterScreenLoadingPanel.Instance.playersReady++;
 					return;
+				}
 
 			if (!_tcsDictionary.ContainsKey(userId))
 				_tcsDictionary[userId] = new Dictionary<string, TaskCompletionSource<EntitlementsStatus>>();
@@ -132,6 +135,7 @@ namespace MultiplayerExtensions.Extensions
 			{
 				result = await _tcsDictionary[userId][levelId].Task.ContinueWith(t => t.IsCompleted ? t.Result : EntitlementsStatus.Unknown);
 				_tcsDictionary[userId][levelId] = new TaskCompletionSource<EntitlementsStatus>();
+				if (result == EntitlementsStatus.Ok) UI.CenterScreenLoadingPanel.Instance.playersReady++;
 			}
 		}
 	}

--- a/MultiplayerExtensions/Extensions/ExtendedGameStateController.cs
+++ b/MultiplayerExtensions/Extensions/ExtendedGameStateController.cs
@@ -94,7 +94,6 @@ namespace MultiplayerExtensions.Extensions
 		{
             if (_multiplayerLevelLoader.GetField<MultiplayerLevelLoader.MultiplayerBeatmapLoaderState, MultiplayerLevelLoader>("_loaderState") == MultiplayerLevelLoader.MultiplayerBeatmapLoaderState.NotLoading)
             {
-                Plugin.Log?.Info("HandleMultiplayerLevelLoaderCountdownFinished already running, returning");
                 return;
             }
             _multiplayerLevelLoader.SetField("_loaderState", MultiplayerLevelLoader.MultiplayerBeatmapLoaderState.NotLoading);

--- a/MultiplayerExtensions/Extensions/ExtendedGameStateController.cs
+++ b/MultiplayerExtensions/Extensions/ExtendedGameStateController.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using IPA.Utilities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -91,7 +92,14 @@ namespace MultiplayerExtensions.Extensions
 
         public async override void HandleMultiplayerLevelLoaderCountdownFinished(IPreviewBeatmapLevel previewBeatmapLevel, BeatmapDifficulty beatmapDifficulty, BeatmapCharacteristicSO beatmapCharacteristic, IDifficultyBeatmap difficultyBeatmap, GameplayModifiers gameplayModifiers)
 		{
+            if (_multiplayerLevelLoader.GetField<MultiplayerLevelLoader.MultiplayerBeatmapLoaderState, MultiplayerLevelLoader>("_loaderState") == MultiplayerLevelLoader.MultiplayerBeatmapLoaderState.NotLoading)
+            {
+                Plugin.Log?.Info("HandleMultiplayerLevelLoaderCountdownFinished already running, returning");
+                return;
+            }
+            _multiplayerLevelLoader.SetField("_loaderState", MultiplayerLevelLoader.MultiplayerBeatmapLoaderState.NotLoading);
             Plugin.Log?.Debug("Map finished loading, waiting for other players...");
+            UI.CenterScreenLoadingPanel.Instance.playersReady = 0;
             _menuRpcManager.SetIsEntitledToLevel(previewBeatmapLevel.levelID, EntitlementsStatus.Ok);
 
             if (_levelStartedOnTime == false)
@@ -116,11 +124,6 @@ namespace MultiplayerExtensions.Extensions
 
             Plugin.Log?.Debug("All players ready, starting game.");
 
-            Plugin.Log?.Debug($"Null Checking previewBeatmapLevel: '{(previewBeatmapLevel == null ? "null" : "not null")}'");
-            Plugin.Log?.Debug($"Null Checking beatmapDifficulty: '{beatmapDifficulty}'");
-            Plugin.Log?.Debug($"Null Checking beatmapCharacteristic: '{(beatmapCharacteristic == null ? "null" : "not null")}'");
-            Plugin.Log?.Debug($"Null Checking difficultyBeatmap: '{(difficultyBeatmap == null ? "null" : "not null")}'");
-            Plugin.Log?.Debug($"Null Checking gameplayModifiers: '{(gameplayModifiers == null ? "null" : "not null")}'");
 
             base.HandleMultiplayerLevelLoaderCountdownFinished(previewBeatmapLevel, beatmapDifficulty, beatmapCharacteristic, difficultyBeatmap, gameplayModifiers);
         }

--- a/MultiplayerExtensions/Extensions/ExtendedPlayer.cs
+++ b/MultiplayerExtensions/Extensions/ExtendedPlayer.cs
@@ -22,7 +22,7 @@ namespace MultiplayerExtensions.Extensions
         /// <summary>
         /// MultiplayerExtensions version reported by BSIPA.
         /// </summary>
-        public SemVer.Version mpexVersion;
+        public Hive.Versioning.Version mpexVersion;
 
         /// <summary>
         /// Player's color set in the plugin config.
@@ -37,7 +37,7 @@ namespace MultiplayerExtensions.Extensions
         public ExtendedPlayer(IConnectedPlayer player)
 		{
             _connectedPlayer = player;
-            this.mpexVersion = Plugin.PluginMetadata.Version;
+            this.mpexVersion = Plugin.ProtocolVersion;
         }
 
         public ExtendedPlayer(IConnectedPlayer player, string platformID, Platform platform, Color playerColor)
@@ -45,11 +45,11 @@ namespace MultiplayerExtensions.Extensions
             _connectedPlayer = player;
             this.platformID = platformID;
             this.platform = platform;
-            this.mpexVersion = Plugin.PluginMetadata.Version;
+            this.mpexVersion = Plugin.ProtocolVersion;
             this.playerColor = playerColor;
         }
 
-        public ExtendedPlayer(IConnectedPlayer player, string platformID, Platform platform, SemVer.Version mpexVersion, Color playerColor)
+        public ExtendedPlayer(IConnectedPlayer player, string platformID, Platform platform, Hive.Versioning.Version mpexVersion, Color playerColor)
         {
             _connectedPlayer = player;
             this.platformID = platformID;
@@ -102,7 +102,7 @@ namespace MultiplayerExtensions.Extensions
         public ExtendedPlayerPacket Init(string platformID, Platform platform, Color playerColor)
         {
             this.platformID = platformID;
-            this.mpexVersion = Plugin.PluginMetadata.Version.ToString();
+            this.mpexVersion = Plugin.ProtocolVersion.ToString();
             this.playerColor = playerColor;
             this.platform = platform;
             return this;

--- a/MultiplayerExtensions/Extensions/ExtendedSessionManager.cs
+++ b/MultiplayerExtensions/Extensions/ExtendedSessionManager.cs
@@ -97,6 +97,7 @@ namespace MultiplayerExtensions.Extensions
 				extendedPlayer.platform = packet.platform;
 				extendedPlayer.playerColor = packet.playerColor;
 				extendedPlayer.mpexVersion = new Hive.Versioning.Version(packet.mpexVersion);
+				extendedPlayerConnectedEvent?.Invoke(extendedPlayer);
 			}
 			else
 			{
@@ -106,9 +107,9 @@ namespace MultiplayerExtensions.Extensions
 				if (Plugin.ProtocolVersion != extendedPlayer.mpexVersion)
 				{
 					Plugin.Log?.Warn("###################################################################");
-					Plugin.Log?.Warn("Different MultiplayerExtensions version detected!");
-					Plugin.Log?.Warn($"The player '{player.userName}' is using MultiplayerExtensions {extendedPlayer.mpexVersion} while you are using MultiplayerExtensions {Plugin.ProtocolVersion}");
-					Plugin.Log?.Warn("For best compatibility all players should use the same version of MultiplayerExtensions.");
+					Plugin.Log?.Warn("Different MultiplayerExtensions protocol detected!");
+					Plugin.Log?.Warn($"The player '{player.userName}' is using MpEx protocol version {extendedPlayer.mpexVersion} while you are using MpEx protocol {Plugin.ProtocolVersion}");
+					Plugin.Log?.Warn("For best compatibility all players should use a compatible version of MultiplayerExtensions/MultiQuestensions.");
 					Plugin.Log?.Warn("###################################################################");
 				}
 

--- a/MultiplayerExtensions/Extensions/ExtendedSessionManager.cs
+++ b/MultiplayerExtensions/Extensions/ExtendedSessionManager.cs
@@ -37,6 +37,10 @@ namespace MultiplayerExtensions.Extensions
 
 			SetLocalPlayerState("modded", true);
 
+			SetLocalPlayerState("ME_Installed", Plugin.IsMappingInstalled);
+			SetLocalPlayerState("NE_Installed", Plugin.IsNoodleInstalled);
+			SetLocalPlayerState("Chroma_Installed", Plugin.IsChromaInstalled);
+
 			connectedEvent += HandleConnected;
 
 			playerConnectedEvent += HandlePlayerConnected;

--- a/MultiplayerExtensions/Extensions/ExtendedSessionManager.cs
+++ b/MultiplayerExtensions/Extensions/ExtendedSessionManager.cs
@@ -92,18 +92,18 @@ namespace MultiplayerExtensions.Extensions
 				extendedPlayer.platformID = packet.platformID;
 				extendedPlayer.platform = packet.platform;
 				extendedPlayer.playerColor = packet.playerColor;
-				extendedPlayer.mpexVersion = new SemVer.Version(packet.mpexVersion);
+				extendedPlayer.mpexVersion = new Hive.Versioning.Version(packet.mpexVersion);
 			}
 			else
 			{
 				Plugin.Log?.Info($"Received 'ExtendedPlayerPacket' from '{player.userId}' with platformID: '{packet.platformID}'  mpexVersion: '{packet.mpexVersion}'");
-				ExtendedPlayer extendedPlayer = new ExtendedPlayer(player, packet.platformID, packet.platform, new SemVer.Version(packet.mpexVersion), packet.playerColor);
+				ExtendedPlayer extendedPlayer = new ExtendedPlayer(player, packet.platformID, packet.platform, new Hive.Versioning.Version(packet.mpexVersion), packet.playerColor);
 
-				if (Plugin.PluginMetadata.Version != extendedPlayer.mpexVersion)
+				if (Plugin.ProtocolVersion != extendedPlayer.mpexVersion)
 				{
 					Plugin.Log?.Warn("###################################################################");
 					Plugin.Log?.Warn("Different MultiplayerExtensions version detected!");
-					Plugin.Log?.Warn($"The player '{player.userName}' is using MultiplayerExtensions {extendedPlayer.mpexVersion} while you are using MultiplayerExtensions {Plugin.PluginMetadata.Version}");
+					Plugin.Log?.Warn($"The player '{player.userName}' is using MultiplayerExtensions {extendedPlayer.mpexVersion} while you are using MultiplayerExtensions {Plugin.ProtocolVersion}");
 					Plugin.Log?.Warn("For best compatibility all players should use the same version of MultiplayerExtensions.");
 					Plugin.Log?.Warn("###################################################################");
 				}

--- a/MultiplayerExtensions/HarmonyPatches/CustomSongsPatches.cs
+++ b/MultiplayerExtensions/HarmonyPatches/CustomSongsPatches.cs
@@ -22,18 +22,6 @@ namespace MultiplayerExtensions.HarmonyPatches
         }
     }
 
-    [HarmonyPatch(typeof(MultiplayerLobbyConnectionController), nameof(MultiplayerLobbyConnectionController.ConnectToMatchmaking), MethodType.Normal)]
-    internal class ConnectToMatchmakingPatch
-	{
-        /// <summary>
-        /// Modifies the data used to matchmake
-        /// </summary>
-        static void Prefix(ref SongPackMask songPackMask)
-        {
-            if (!MPState.CurrentMasterServer.isOfficial)
-                songPackMask |= new SongPackMask("custom_levelpack_CustomLevels");
-        }
-    }
 
     [HarmonyPatch(typeof(MultiplayerLevelSelectionFlowCoordinator), "enableCustomLevels", MethodType.Getter)]
     internal class EnableCustomLevelsPatch

--- a/MultiplayerExtensions/HarmonyPatches/InstallerPatches.cs
+++ b/MultiplayerExtensions/HarmonyPatches/InstallerPatches.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using IPA.Utilities;
 using MultiplayerExtensions.Extensions;
 using System;
 using System.Collections.Generic;
@@ -145,7 +146,7 @@ namespace MultiplayerExtensions.HarmonyPatches
             ____sceneSetupData = new GameplayCoreSceneSetupData(
                 ____sceneSetupData.difficultyBeatmap,
                 ____sceneSetupData.previewBeatmapLevel,
-                ____sceneSetupData.gameplayModifiers.CopyWith(zenMode: Plugin.Config.LagReducer),
+                ____sceneSetupData.gameplayModifiers.CopyWith(zenMode: (____sceneSetupData.gameplayModifiers.zenMode || Plugin.Config.LagReducer)),
                 ____sceneSetupData.playerSpecificSettings,
                 ____sceneSetupData.practiceSettings,
                 ____sceneSetupData.useTestNoteCutSoundEffects,

--- a/MultiplayerExtensions/HarmonyPatches/QuickplayPatches.cs
+++ b/MultiplayerExtensions/HarmonyPatches/QuickplayPatches.cs
@@ -12,11 +12,12 @@ namespace MultiplayerExtensions.HarmonyPatches
     [HarmonyPatch(typeof(MultiplayerModeSelectionFlowCoordinator), nameof(MultiplayerModeSelectionFlowCoordinator.HandleJoinQuickPlayViewControllerDidFinish), MethodType.Normal)]
     internal class MultiplayerModeSelectionFlowCoordinatorPatch
     {
+        internal static bool skipCheck = false;
         static bool Prefix(MultiplayerModeSelectionFlowCoordinator __instance, bool success, JoinQuickPlayViewController ____joinQuickPlayViewController, SimpleDialogPromptViewController ____simpleDialogPromptViewController, SongPackMaskModelSO ____songPackMaskModel)
         {
             string levelPackName = ____joinQuickPlayViewController.multiplayerModeSettings.quickPlaySongPackMaskSerializedName;
             Plugin.Log?.Debug(levelPackName);
-            if (success && ____songPackMaskModel.ToSongPackMask(levelPackName).Contains("custom_levelpack_CustomLevels"))
+            if (success && ____songPackMaskModel.ToSongPackMask(levelPackName).Contains("custom_levelpack_CustomLevels") && !skipCheck)
             {
                 ____simpleDialogPromptViewController.Init(
                     "Custom Song Quickplay",
@@ -29,6 +30,7 @@ namespace MultiplayerExtensions.HarmonyPatches
                         {
                             default:
                             case 0: // Continue
+                                skipCheck = true;
                                 __instance.HandleJoinQuickPlayViewControllerDidFinish(true);
                                 break;
                             case 1: // Cancel
@@ -44,6 +46,7 @@ namespace MultiplayerExtensions.HarmonyPatches
                                 });
                 return false;
             }
+            skipCheck = false;
             return true;
         }
     }

--- a/MultiplayerExtensions/MultiplayerExtensions.csproj
+++ b/MultiplayerExtensions/MultiplayerExtensions.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>MultiplayerExtensions</AssemblyName>
-    <AssemblyVersion>0.6.1</AssemblyVersion>
+    <AssemblyVersion>0.6.2</AssemblyVersion>
     <TargetFramework>net472</TargetFramework>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>

--- a/MultiplayerExtensions/Plugin.cs
+++ b/MultiplayerExtensions/Plugin.cs
@@ -27,6 +27,8 @@ namespace MultiplayerExtensions
 
         internal static Plugin Instance { get; private set; } = null!;
         internal static PluginMetadata PluginMetadata = null!;
+
+        internal static Hive.Versioning.Version ProtocolVersion { get; } = new Hive.Versioning.Version("1.0.0");
         internal static IPALogger Log { get; private set; } = null!;
         internal static PluginConfig Config = null!;
 

--- a/MultiplayerExtensions/Plugin.cs
+++ b/MultiplayerExtensions/Plugin.cs
@@ -3,20 +3,16 @@ using IPA;
 using IPA.Config;
 using IPA.Config.Stores;
 using IPA.Loader;
-using MultiplayerExtensions.HarmonyPatches;
 using MultiplayerExtensions.Installers;
 using SiraUtil.Zenject;
 using MultiplayerExtensions.Utilities;
 using System;
-using System.Reflection;
 using System.Threading.Tasks;
 using IPALogger = IPA.Logging.Logger;
 using BeatSaverSharp;
 using System.Diagnostics;
-using Zenject;
 using MultiplayerExtensions.UI;
 using BeatSaberMarkupLanguage.Settings;
-using System.Net.Http;
 
 namespace MultiplayerExtensions
 {
@@ -36,7 +32,6 @@ namespace MultiplayerExtensions
         internal static IPALogger Log { get; private set; } = null!;
         internal static PluginConfig Config = null!;
 
-        internal static HttpClient HttpClient { get; private set; } = null!;
         internal static BeatSaver BeatSaver = null!;
         internal static Harmony? _harmony;
         internal static Harmony Harmony
@@ -47,15 +42,6 @@ namespace MultiplayerExtensions
             }
         }
 
-        public static string UserAgent
-        {
-            get
-            {
-                var modVersion = PluginMetadata.Version.ToString();
-                var bsVersion = IPA.Utilities.UnityGame.GameVersion.ToString();
-                return $"MultiplayerExtensions/{modVersion} (BeatSaber/{bsVersion})";
-            }
-        }
 
         private const int MaxPlayers = 100;
         private const int MinPlayers = 10;
@@ -73,9 +59,8 @@ namespace MultiplayerExtensions
             zenjector.OnGame<MPGameInstaller>().OnlyForMultiplayer();
 
             BeatSaverOptions options = new BeatSaverOptions("MultiplayerExtensions", new Version(pluginMetadata.Version.ToString()));
+            options.Timeout = TimeSpan.FromMinutes(1);
             BeatSaver = new BeatSaver(options);
-            HttpClient = new HttpClient();
-            HttpClient.DefaultRequestHeaders.Add("User-Agent", Plugin.UserAgent);
         }
 
         [OnStart]

--- a/MultiplayerExtensions/Plugin.cs
+++ b/MultiplayerExtensions/Plugin.cs
@@ -28,7 +28,11 @@ namespace MultiplayerExtensions
         internal static Plugin Instance { get; private set; } = null!;
         internal static PluginMetadata PluginMetadata = null!;
 
-        internal static Hive.Versioning.Version ProtocolVersion { get; } = new Hive.Versioning.Version("1.0.0");
+        internal static bool IsNoodleInstalled { get; private set; }
+        internal static bool IsMappingInstalled { get; private set; }
+        internal static bool IsChromaInstalled { get; private set; }
+
+        internal static Hive.Versioning.Version ProtocolVersion { get; } = new Hive.Versioning.Version("0.7.1");
         internal static IPALogger Log { get; private set; } = null!;
         internal static PluginConfig Config = null!;
 
@@ -84,6 +88,11 @@ namespace MultiplayerExtensions
 
             HarmonyManager.ApplyDefaultPatches();
             Task versionTask = CheckVersion();
+
+            IsNoodleInstalled = IPA.Loader.PluginManager.IsEnabled(IPA.Loader.PluginManager.GetPluginFromId("NoodleExtensions"));
+            IsMappingInstalled = IPA.Loader.PluginManager.IsEnabled(IPA.Loader.PluginManager.GetPluginFromId("MappingExtensions"));
+            IsChromaInstalled = IPA.Loader.PluginManager.IsEnabled(IPA.Loader.PluginManager.GetPluginFromId("Chroma"));
+
             MPEvents_Test();
             
             Sprites.PreloadSprites();

--- a/MultiplayerExtensions/UI/CenterScreenLoadingPanel.cs
+++ b/MultiplayerExtensions/UI/CenterScreenLoadingPanel.cs
@@ -15,20 +15,23 @@ namespace MultiplayerExtensions.UI
         private CenterStageScreenController screenController;
         private LoadingControl? loadingControl;
         private bool isDownloading;
-        public static CenterScreenLoadingPanel? self { get; private set; }
+        public int playersReady;
+        public static CenterScreenLoadingPanel? Instance { get; private set; }
 
         [Inject]
         internal void Inject(IMultiplayerSessionManager sessionManager, ILobbyGameStateController gameStateController, CenterStageScreenController screenController)
         {
-            self = this;
+            Instance = this;
             this.sessionManager = sessionManager;
             this.gameStateController = gameStateController;
             this.screenController = screenController;
 
             BeatSaberMarkupLanguage.Tags.VerticalLayoutTag verticalTag = new BeatSaberMarkupLanguage.Tags.VerticalLayoutTag();
             GameObject vertical = verticalTag.CreateObject(transform);
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
             (vertical.transform as RectTransform).sizeDelta = new Vector2(60, 60);
             (vertical.transform as RectTransform).anchoredPosition = new Vector2(0.0f, -30.0f);
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
             var layout = vertical.AddComponent<LayoutElement>().minWidth = 60;
 
             GameObject existingLoadingControl = Resources.FindObjectsOfTypeAll<LoadingControl>().First().gameObject;
@@ -37,7 +40,7 @@ namespace MultiplayerExtensions.UI
             loadingControl.Hide();
         }
 
-        public void Update()
+        public void FixedUpdate()
         {
             if (isDownloading)
             {
@@ -46,12 +49,13 @@ namespace MultiplayerExtensions.UI
             else if (screenController.countdownShown && sessionManager.syncTime >= gameStateController.startTime && gameStateController.levelStartInitiated)
             {
                 if (loadingControl != null)
-                    loadingControl.ShowLoading("Loading...");
+                    loadingControl.ShowLoading($"{playersReady + 1} of {(sessionManager.connectedPlayerCount + 1)} players ready...");
             }
             else
             {
                 if (loadingControl != null)
                     loadingControl.Hide();
+                playersReady = 0;
             }
         }
 
@@ -59,6 +63,7 @@ namespace MultiplayerExtensions.UI
         {
             if (loadingControl != null)
                 loadingControl.Hide();
+            playersReady = 0;
         }
 
         public void Report(double value)

--- a/MultiplayerExtensions/UI/CenterScreenLoadingPanel.cs
+++ b/MultiplayerExtensions/UI/CenterScreenLoadingPanel.cs
@@ -71,7 +71,7 @@ namespace MultiplayerExtensions.UI
             isDownloading = (value < 1.0);
             if (loadingControl != null)
             {
-                loadingControl.ShowDownloadingProgress("Downloading...", (float)value);
+                loadingControl.ShowDownloadingProgress($"Downloading ({value * 100:F2}%)...", (float)value);
             }
         }
     }

--- a/MultiplayerExtensions/Utilities/Harmony/HarmonyManager.cs
+++ b/MultiplayerExtensions/Utilities/Harmony/HarmonyManager.cs
@@ -23,7 +23,6 @@ namespace MultiplayerExtensions.Utilities
         {
             AddDefaultPatch<EnableCustomLevelsPatch>();
             AddDefaultPatch<CreatePartyPatch>();
-            AddDefaultPatch<ConnectToMatchmakingPatch>();
             AddDefaultPatch<MultiplayerBigAvatarAnimator_Init>();
             AddDefaultPatch<GetMasterServerEndPointPatch>();
             AddDefaultPatch<SetLobbyCodePatch>();

--- a/MultiplayerExtensions/manifest.json
+++ b/MultiplayerExtensions/manifest.json
@@ -3,7 +3,7 @@
   "id": "MultiplayerExtensions",
   "name": "MultiplayerExtensions",
   "author": "Zingabopp and Goobwabber",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Expands the functionality of Beat Saber Multiplayer.",
   "gameVersion": "1.17.1",
   "dependsOn": {


### PR DESCRIPTION
With QuickplaySongPackOverrides we no longer need to patch `ConnectToMatchmaking`, fixed issue with the warning message as well.
Improved CenterScreenLoadingPanel with Download Indicator and Loading Indicator.
Check Mod requirements on Entitlement Check.
Allow live color updates for MQE players

This should take care of #137
Is issue #59 still an issue here?