### PR TITLE
README: Replace MultiplayerCore requirement with BeatTogether

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Lastly, check out [other mods](https://github.com/Goobwabber/MultiplayerExtensio
 
 ## Requirements
 These can be downloaded from [BeatMods](https://beatmods.com/#/mods) or using Mod Assistant. **Do NOT use any of the DLLs in the `Refs` folder, they have been stripped of code and will not work.**
-* MultiplayerCore v1.0.0+
 * BeatSaberMarkupLanguage v1.5.1+
 * SiraUtil 3.0.0+
+* BeatTogether v1.2.0+
 
 ## Reporting Issues
 * The best way to report issues is to click on the `Issues` tab at the top of the GitHub page. This allows any contributor to see the problem and attempt to fix it, and others with the same issue can contribute more information. **Please try the troubleshooting steps before reporting the issues listed there. Please only report issues after using the latest build, your problem may have already been fixed.**


### PR DESCRIPTION
MultiplayerCore is no longer required to run MultiplayerExtensions, and is no longer maintained. However, the mod does not work without a private server installed, such as BeatTogether.