### PR TITLE
Update for Beat Saber 1.34.2

### DIFF
--- a/MultiplayerExtensions/Environment/MpexAvatarNameTag.cs
+++ b/MultiplayerExtensions/Environment/MpexAvatarNameTag.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using HMUI;
+using BeatSaber.AvatarCore;
 using MultiplayerCore.Players;
 using MultiplayerExtensions.Players;
 using MultiplayerExtensions.Utilities;

--- a/MultiplayerExtensions/Environment/MpexPlayerTableCell.cs
+++ b/MultiplayerExtensions/Environment/MpexPlayerTableCell.cs
@@ -25,7 +25,7 @@ namespace MultiplayerExtensions.Objects
 
         internal MpexPlayerTableCell(
             ServerPlayerListViewController playerListView,
-            NetworkPlayerEntitlementChecker entitlementChecker,
+            MpEntitlementChecker entitlementChecker,
             ILobbyPlayersDataModel playersDataModel,
             IMenuRpcManager menuRpcManager)
         {
@@ -47,15 +47,15 @@ namespace MultiplayerExtensions.Objects
 
         [AffinityPrefix]
         [AffinityPatch(typeof(GameServerPlayerTableCell), nameof(GameServerPlayerTableCell.SetData))]
-        public void SetDataPrefix(IConnectedPlayer connectedPlayer, ILobbyPlayerData playerData, bool hasKickPermissions, bool allowSelection, Task<AdditionalContentModel.EntitlementStatus> getLevelEntitlementTask, Image ____localPlayerBackgroundImage)
+        public void SetDataPrefix(IConnectedPlayer connectedPlayer, ILobbyPlayerData playerData, bool hasKickPermissions, bool allowSelection, Task<EntitlementsStatus> getLevelEntitlementTask, Image ____localPlayerBackgroundImage)
         {
             if (getLevelEntitlementTask != null)
-                getLevelEntitlementTask = Task.FromResult(AdditionalContentModel.EntitlementStatus.Owned);
+                getLevelEntitlementTask = Task.FromResult(EntitlementsStatus.Ok);
         }
 
         [AffinityPostfix]
         [AffinityPatch(typeof(GameServerPlayerTableCell), nameof(GameServerPlayerTableCell.SetData))]
-        public void SetDataPostfix(IConnectedPlayer connectedPlayer, ILobbyPlayerData playerData, bool hasKickPermissions, bool allowSelection, Task<AdditionalContentModel.EntitlementStatus> getLevelEntitlementTask, Image ____localPlayerBackgroundImage)
+        public void SetDataPostfix(IConnectedPlayer connectedPlayer, ILobbyPlayerData playerData, bool hasKickPermissions, bool allowSelection, Task<EntitlementsStatus> getLevelEntitlementTask, Image ____localPlayerBackgroundImage)
         {
             ____localPlayerBackgroundImage.enabled = true;
             string? hostSelectedLevel = _playersDataModel[_playersDataModel.partyOwnerId].beatmapLevel?.beatmapLevel?.levelID;

--- a/MultiplayerExtensions/MultiplayerExtensions.csproj
+++ b/MultiplayerExtensions/MultiplayerExtensions.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>MultiplayerExtensions</AssemblyName>
-    <AssemblyVersion>1.0.3</AssemblyVersion>
+    <AssemblyVersion>1.0.4</AssemblyVersion>
     <TargetFramework>net472</TargetFramework>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
@@ -17,8 +17,10 @@
     <Nullable>enable</Nullable>
     <VersionType>Unofficial</VersionType>
     <CommitHash>local</CommitHash>
-    <GitBranch></GitBranch>
-    <GitModified></GitModified>
+    <GitBranch>
+    </GitBranch>
+    <GitModified>
+    </GitModified>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <Optimize>false</Optimize>
@@ -37,6 +39,21 @@
   <ItemGroup>
     <Reference Include="BeatmapCore">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BeatSaber.AvatarCore" Publicize="true">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.AvatarCore.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BGLib.AppFlow" Publicize="true">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BGLib.UnityExtension">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.UnityExtension.dll</HintPath>
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
@@ -71,6 +88,11 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="Networking">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Networking.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="Polyglot">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Polyglot.dll</HintPath>
       <Private>False</Private>
@@ -84,7 +106,7 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="Main">
+    <Reference Include="Main" Publicize="true">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
       <Private>False</Private>
     </Reference>
@@ -203,14 +225,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BeatSaberModdingTools.Tasks">
-      <Version>1.3.2</Version>
+      <Version>1.4.3</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" />
+    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" PrivateAssets="all" />
     <!-- Publicize directly when referencing -->
     <Reference Include="$(BeatSaberDir)\Plugins\MultiplayerCore.dll" Publicize="true" />
   </ItemGroup>

--- a/MultiplayerExtensions/Patches/AvatarPoseRestrictionPatch.cs
+++ b/MultiplayerExtensions/Patches/AvatarPoseRestrictionPatch.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using BeatSaber.AvatarCore;
+using HarmonyLib;
 using UnityEngine;
 
 namespace MultiplayerExtensions.Patches
@@ -7,8 +8,8 @@ namespace MultiplayerExtensions.Patches
     public class AvatarPoseRestrictionPatch
     {
         [HarmonyPrefix]
-        [HarmonyPatch(typeof(AvatarPoseRestrictions), nameof(AvatarPoseRestrictions.HandleAvatarPoseControllerPositionsWillBeSet))]
-        private static bool DisableAvatarRestrictions(AvatarPoseRestrictions __instance, Vector3 headPosition, Vector3 leftHandPosition, Vector3 rightHandPosition, out Vector3 newHeadPosition, out Vector3 newLeftHandPosition, out Vector3 newRightHandPosition)
+        [HarmonyPatch(typeof(LimitAvatarPoseRestriction), nameof(LimitAvatarPoseRestriction.RestrictPose))]
+        private static bool DisableAvatarRestrictions(LimitAvatarPoseRestriction __instance, Vector3 headPosition, Vector3 leftHandPosition, Vector3 rightHandPosition, out Vector3 newHeadPosition, out Vector3 newLeftHandPosition, out Vector3 newRightHandPosition)
         {
             newHeadPosition = headPosition;
             newLeftHandPosition = leftHandPosition;

--- a/MultiplayerExtensions/UI/MpexSettingsViewController.bsml
+++ b/MultiplayerExtensions/UI/MpexSettingsViewController.bsml
@@ -2,9 +2,9 @@
 	<horizontal anchor-min-y='1'  bg='panel-top' pad-left='10' pad-right='10' horizontal-fit='PreferredSize'>
 	</horizontal>
 	<settings-container>
-    <toggle-setting value='hide-player-platforms' apply-on-change='true' text='Hide Player Platforms' hover-hint="Hides other player's platforms in game." bind-value='true'/>
-    <toggle-setting value='hide-player-lights' apply-on-change='true' text='Hide Player Lights' hover-hint="Hides other player's platform lights in game." bind-value='true'/>
-    <toggle-setting value='hide-player-objects' apply-on-change='true' text='Hide Player Objects' hover-hint="Hides other player's notes and walls in game." bind-value='true'/>
+    <toggle-setting value='hide-player-platforms' apply-on-change='true' text='Hide Player Platforms' hover-hint="Hides other players' platforms in game." bind-value='true'/>
+    <toggle-setting value='hide-player-lights' apply-on-change='true' text='Hide Player Lights' hover-hint="Hides other players' platform lights in game." bind-value='true'/>
+	<toggle-setting value='hide-player-objects' apply-on-change='true' text='Hide Player Objects' hover-hint="Hides other players' notes, bombs and walls in game." bind-value='true'/>
     <toggle-setting value='miss-lighting' apply-on-change='true' text='Miss Lighting' hover-hint="Turns a player's platform red when they miss a note." bind-value='true'/>
     <toggle-setting id='personal-miss-lighting-toggle' value='personal-miss-lighting-only' apply-on-change='true' text='Personal Only Miss Lighting' hover-hint="Makes miss lighting only apply to your platform." bind-value='true'/>
 	</settings-container>

--- a/MultiplayerExtensions/manifest.json
+++ b/MultiplayerExtensions/manifest.json
@@ -3,9 +3,9 @@
   "id": "MultiplayerExtensions",
   "name": "MultiplayerExtensions",
   "author": "Goobwabber",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Expands the functionality of Beat Saber Multiplayer.",
-  "gameVersion": "1.24.0",
+  "gameVersion": "1.34.2",
   "dependsOn": {
     "BSIPA": "^4.1.4",
     "BeatSaberMarkupLanguage": "^1.5.1",


### PR DESCRIPTION
This PR performs a few updates to make Multiplayer Extensions compatible with Beat Saber 1.34.2 (and possible 1.33.0).  This also performs some slight UI string tweaks.